### PR TITLE
Refactoring: removes code duplication with dynamic dispatch

### DIFF
--- a/src/center.rs
+++ b/src/center.rs
@@ -1,0 +1,9 @@
+use crate::{Location, QueryStringable};
+
+pub type Center = Location;
+
+impl QueryStringable for Center {
+    fn as_query_params(&self) -> Vec<(String, String)> {
+        vec![("center".to_string(), self.to_string())]
+    }
+}

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,10 +1,11 @@
+use crate::QueryStringable;
 use std::fmt;
 
-pub const PNG: &Format = &Format::Png;
-pub const PNG32: &Format = &Format::Png32;
-pub const GIF: &Format = &Format::Gif;
-pub const JPEG: &Format = &Format::Jpeg;
-pub const JPEG_BASELINE: &Format = &Format::JpegBaseline;
+pub const PNG: Format = Format::Png;
+pub const PNG32: Format = Format::Png32;
+pub const GIF: Format = Format::Gif;
+pub const JPEG: Format = Format::Jpeg;
+pub const JPEG_BASELINE: Format = Format::JpegBaseline;
 
 #[derive(Clone, Copy)]
 pub enum Format {
@@ -28,5 +29,11 @@ impl fmt::Display for Format {
                 Format::JpegBaseline => "jpg-baseline",
             }
         )
+    }
+}
+
+impl QueryStringable for Format {
+    fn as_query_params(&self) -> Vec<(String, String)> {
+        vec![("format".to_string(), self.to_string())]
     }
 }

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,0 +1,16 @@
+use crate::QueryStringable;
+
+#[derive(Clone)]
+pub struct Language(&'static str);
+
+impl QueryStringable for Language {
+    fn as_query_params(&self) -> Vec<(String, String)> {
+        vec![("language".to_string(), self.0.to_string())]
+    }
+}
+
+impl From<&'static str> for Language {
+    fn from(language: &'static str) -> Self {
+        Language(language)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ impl QueryStringable for Center {
     }
 }
 
+// TODO: see if it can be avoided with generic impl block for Vec<QueryStringable>
 type Markers<S> = Vec<Marker<S>>;
 
 impl<S: AsRef<str> + Clone> QueryStringable for Markers<S> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod center;
 mod color;
 mod credentials;
 mod format;
@@ -11,12 +12,14 @@ mod marker_label;
 mod marker_scale;
 mod marker_size;
 mod marker_style;
+mod querystringable;
 mod relative_position;
 mod scale;
 mod signature;
 mod size;
 mod zoom;
 
+pub use center::*;
 pub use color::*;
 pub use credentials::*;
 pub use format::*;
@@ -30,6 +33,7 @@ pub use marker_label::*;
 pub use marker_scale::*;
 pub use marker_size::*;
 pub use marker_style::*;
+pub use querystringable::*;
 pub use relative_position::*;
 pub use scale::*;
 use signature::*;
@@ -57,36 +61,7 @@ pub struct UrlBuilder<S: AsRef<str> + Clone> {
     markers: Vec<Marker<S>>,
 }
 
-trait QueryStringable {
-    fn as_query_params(&self) -> Vec<(String, String)>;
-}
-
 static BASE_URL: &str = "https://maps.googleapis.com/maps/api/staticmap";
-
-type Center = Location;
-
-impl QueryStringable for Center {
-    fn as_query_params(&self) -> Vec<(String, String)> {
-        vec![("center".to_string(), self.to_string())]
-    }
-}
-
-impl<T: QueryStringable> QueryStringable for Option<T> {
-    fn as_query_params(&self) -> Vec<(String, String)> {
-        match self {
-            Some(v) => v.as_query_params(),
-            None => vec![],
-        }
-    }
-}
-
-impl<T: QueryStringable> QueryStringable for Vec<T> {
-    fn as_query_params(&self) -> Vec<(String, String)> {
-        self.iter()
-            .flat_map(|item| item.as_query_params())
-            .collect()
-    }
-}
 
 impl<S: AsRef<str> + Clone> UrlBuilder<S> {
     pub fn new(credentials: Credentials<S>, size: Size) -> Self {
@@ -104,6 +79,8 @@ impl<S: AsRef<str> + Clone> UrlBuilder<S> {
         }
     }
 
+    // TODO: reconsider whether this (and following methods) should be immutable
+    //       users could rely on an explicit clone if they want to keep copies around
     pub fn center(&self, center: Location) -> Self {
         UrlBuilder {
             center: Some(center),

--- a/src/maptype.rs
+++ b/src/maptype.rs
@@ -1,9 +1,10 @@
+use crate::QueryStringable;
 use std::fmt;
 
-pub static ROADMAP: &MapType = &MapType::RoadMap;
-pub static SATELLITE: &MapType = &MapType::Satellite;
-pub static TERRAIN: &MapType = &MapType::Terrain;
-pub static HYBRID: &MapType = &MapType::Hybrid;
+pub const ROADMAP: MapType = MapType::RoadMap;
+pub const SATELLITE: MapType = MapType::Satellite;
+pub const TERRAIN: MapType = MapType::Terrain;
+pub const HYBRID: MapType = MapType::Hybrid;
 
 #[derive(Clone, Copy)]
 pub enum MapType {
@@ -26,5 +27,11 @@ impl fmt::Display for MapType {
                 Hybrid => String::from("hybrid"),
             }
         )
+    }
+}
+
+impl QueryStringable for MapType {
+    fn as_query_params(&self) -> Vec<(String, String)> {
+        vec![("maptype".to_string(), self.to_string())]
     }
 }

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -1,4 +1,4 @@
-use crate::{Color, Location, MarkerAppearence, MarkerScale, MarkerStyle};
+use crate::{Color, Location, MarkerAppearence, MarkerScale, MarkerStyle, QueryStringable};
 use std::fmt;
 
 #[derive(Clone)]
@@ -78,6 +78,12 @@ impl<S: AsRef<str> + Clone> fmt::Display for Marker<S> {
         }
 
         write!(f, "{}", parts.join("|"))
+    }
+}
+
+impl<S: AsRef<str> + Clone> QueryStringable for Marker<S> {
+    fn as_query_params(&self) -> Vec<(String, String)> {
+        vec![("markers".to_string(), self.to_string())]
     }
 }
 

--- a/src/querystringable.rs
+++ b/src/querystringable.rs
@@ -1,0 +1,20 @@
+pub trait QueryStringable {
+    fn as_query_params(&self) -> Vec<(String, String)>;
+}
+
+impl<T: QueryStringable> QueryStringable for Option<T> {
+    fn as_query_params(&self) -> Vec<(String, String)> {
+        match self {
+            Some(v) => v.as_query_params(),
+            None => vec![],
+        }
+    }
+}
+
+impl<T: QueryStringable> QueryStringable for Vec<T> {
+    fn as_query_params(&self) -> Vec<(String, String)> {
+        self.iter()
+            .flat_map(|item| item.as_query_params())
+            .collect()
+    }
+}

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,0 +1,16 @@
+use crate::QueryStringable;
+
+#[derive(Clone)]
+pub struct Region(&'static str);
+
+impl QueryStringable for Region {
+    fn as_query_params(&self) -> Vec<(String, String)> {
+        vec![("region".to_string(), self.0.to_string())]
+    }
+}
+
+impl From<&'static str> for Region {
+    fn from(region: &'static str) -> Self {
+        Region(region)
+    }
+}

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -1,7 +1,8 @@
+use crate::QueryStringable;
 use std::fmt;
 
-pub static SCALE1: &Scale = &Scale::S1;
-pub static SCALE2: &Scale = &Scale::S2;
+pub const SCALE1: Scale = Scale::S1;
+pub const SCALE2: Scale = Scale::S2;
 
 #[derive(Clone)]
 pub enum Scale {
@@ -20,5 +21,11 @@ impl fmt::Display for Scale {
                 S2 => "2",
             }
         )
+    }
+}
+
+impl QueryStringable for Scale {
+    fn as_query_params(&self) -> Vec<(String, String)> {
+        vec![("scale".to_string(), self.to_string())]
     }
 }

--- a/src/size.rs
+++ b/src/size.rs
@@ -1,3 +1,4 @@
+use crate::QueryStringable;
 use std::fmt;
 
 #[derive(Clone)]
@@ -26,5 +27,11 @@ impl fmt::Display for Size {
 impl From<(i32, i32)> for Size {
     fn from(s: (i32, i32)) -> Self {
         Size::new(s.0, s.1)
+    }
+}
+
+impl QueryStringable for Size {
+    fn as_query_params(&self) -> Vec<(String, String)> {
+        vec![("size".to_string(), self.to_string())]
     }
 }

--- a/src/zoom.rs
+++ b/src/zoom.rs
@@ -1,34 +1,35 @@
+use crate::QueryStringable;
 use std::fmt;
 
 #[derive(Clone)]
 pub struct Zoom(u8);
 
-pub static WORLD: &Zoom = &Zoom(1);
-pub static ZOOM_1: &Zoom = WORLD; // alias
-pub static ZOOM_2: &Zoom = &Zoom(2);
-pub static ZOOM_3: &Zoom = &Zoom(3);
-pub static ZOOM_4: &Zoom = &Zoom(4);
-pub static CONTINENT: &Zoom = &Zoom(5);
-pub static ZOOM_5: &Zoom = CONTINENT; // alias
-pub static ZOOM_6: &Zoom = &Zoom(6);
-pub static ZOOM_7: &Zoom = &Zoom(7);
-pub static ZOOM_8: &Zoom = &Zoom(8);
-pub static ZOOM_9: &Zoom = &Zoom(9);
-pub static CITY: &Zoom = &Zoom(10);
-pub static ZOOM_10: &Zoom = CITY; // alias
-pub static ZOOM_11: &Zoom = &Zoom(11);
-pub static ZOOM_12: &Zoom = &Zoom(12);
-pub static ZOOM_13: &Zoom = &Zoom(13);
-pub static ZOOM_14: &Zoom = &Zoom(14);
-pub static STREETS: &Zoom = &Zoom(15);
-pub static ZOOM_15: &Zoom = STREETS; // alias
-pub static ZOOM_16: &Zoom = &Zoom(16);
-pub static ZOOM_17: &Zoom = &Zoom(17);
-pub static ZOOM_18: &Zoom = &Zoom(18);
-pub static ZOOM_19: &Zoom = &Zoom(19);
-pub static BUILDINGS: &Zoom = &Zoom(20);
-pub static ZOOM_20: &Zoom = BUILDINGS; // alias
-pub static ZOOM_21: &Zoom = &Zoom(21);
+pub const WORLD: Zoom = Zoom(1);
+pub const ZOOM_1: Zoom = WORLD; // alias
+pub const ZOOM_2: Zoom = Zoom(2);
+pub const ZOOM_3: Zoom = Zoom(3);
+pub const ZOOM_4: Zoom = Zoom(4);
+pub const CONTINENT: Zoom = Zoom(5);
+pub const ZOOM_5: Zoom = CONTINENT; // alias
+pub const ZOOM_6: Zoom = Zoom(6);
+pub const ZOOM_7: Zoom = Zoom(7);
+pub const ZOOM_8: Zoom = Zoom(8);
+pub const ZOOM_9: Zoom = Zoom(9);
+pub const CITY: Zoom = Zoom(10);
+pub const ZOOM_10: Zoom = CITY; // alias
+pub const ZOOM_11: Zoom = Zoom(11);
+pub const ZOOM_12: Zoom = Zoom(12);
+pub const ZOOM_13: Zoom = Zoom(13);
+pub const ZOOM_14: Zoom = Zoom(14);
+pub const STREETS: Zoom = Zoom(15);
+pub const ZOOM_15: Zoom = STREETS; // alias
+pub const ZOOM_16: Zoom = Zoom(16);
+pub const ZOOM_17: Zoom = Zoom(17);
+pub const ZOOM_18: Zoom = Zoom(18);
+pub const ZOOM_19: Zoom = Zoom(19);
+pub const BUILDINGS: Zoom = Zoom(20);
+pub const ZOOM_20: Zoom = BUILDINGS; // alias
+pub const ZOOM_21: Zoom = Zoom(21);
 
 impl Zoom {
     pub fn new(zoom: u8) -> Self {
@@ -52,5 +53,11 @@ impl From<u8> for Zoom {
 impl From<i32> for Zoom {
     fn from(zoom: i32) -> Self {
         Zoom::new(zoom as u8)
+    }
+}
+
+impl QueryStringable for Zoom {
+    fn as_query_params(&self) -> Vec<(String, String)> {
+        vec![("zoom".to_string(), self.to_string())]
     }
 }


### PR DESCRIPTION
Introduces the `QueryStringable` type to reduce code duplication on serializing query string parameters